### PR TITLE
Fix compilation if $CXX contains a full path

### DIFF
--- a/configure
+++ b/configure
@@ -87,6 +87,6 @@ fi
 msg "Compiling with '$COMPILE'"
 
 rm -f makefile
-sed -e "s/@COMPILE@/$COMPILE/" makefile.in > makefile
+sed -e "s#@COMPILE@#$COMPILE#" makefile.in > makefile
 
 msg "Generated 'makefile' (run 'make' to compile)"


### PR DESCRIPTION
If the $CXX environment variable contains a full path like `/bin/g++` the `sed` commands gets confused because `/` does not work as a delimiter anymore. As a dirty quick fix, I changed the delimiter to `#`.