### PR TITLE
Fixed generate throwing an error when included as git submodule

### DIFF
--- a/generate
+++ b/generate
@@ -4,7 +4,7 @@ die () {
   exit 1
 }
 [ -f VERSION ] || die "could not find 'VERSION' file"
-[ `git rev-parse --is-inside-work-tree` ] || die "not inside a git repo"
+[ `git rev-parse --is-inside-work-tree > /dev/null 2>&1;` ] || die "not inside a git repo"
 [ -f makefile ] || die "could not find 'makefile'"
 VERSION="`cat VERSION`"
 GITID="`git show|head -1|awk '{print $2}'`"

--- a/generate
+++ b/generate
@@ -4,7 +4,7 @@ die () {
   exit 1
 }
 [ -f VERSION ] || die "could not find 'VERSION' file"
-[ -d .git ] || die "could not find '.git' directory"
+[ `git rev-parse --is-inside-work-tree` ] || die "not inside a git repo"
 [ -f makefile ] || die "could not find 'makefile'"
 VERSION="`cat VERSION`"
 GITID="`git show|head -1|awk '{print $2}'`"


### PR DESCRIPTION
Generate would throw an error `.git` directory not found when included as a git submodule as submodules only have a `.git` file.

I assume the check was to make sure the script is inside a git repository. Replaced it with a check that works for both standalone repositories and submodules.