### PR TITLE
Fix compile args order

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -4,7 +4,7 @@ all: libcadiback.a libcadiback.so
 libcadiback.a: cadiback.o ../cadical/build/libcadical.a makefile
 	$(LINK) rcs $@ cadiback.o
 libcadiback.so: cadiback.o ../cadical/build/libcadical.so makefile
-	$(COMPILE) -shared -o $@ -L../cadical/build/ -lcadical cadiback.o
+	$(COMPILE) -shared -o $@ cadiback.o -L../cadical/build/ -lcadical
 cadiback.o: cadiback.cpp config.hpp ../cadical/src/cadical.hpp makefile
 	$(COMPILE) -c $< -I../cadical/src
 config.hpp: generate VERSION makefile


### PR DESCRIPTION
Hi, thank you for your work on this!
I am working on updated Julia bindings for CryptoMiniSat (see [here](https://github.com/JuliaPackaging/Yggdrasil/pull/12138)) and encountered a problem when building for Windows, which can be fixed by reordering the arguments when compiling the CaDiBack shared library.

This change would allow compiling CaDiBack without an additional [patch for Windows](https://github.com/JuliaPackaging/Yggdrasil/blob/8a1515535482e60327664fce74d23d766ea05707/C/CryptoMiniSat/bundled/patches/cadiback-windows-link-order.patch) for future versions.
Thanks!